### PR TITLE
7.2

### DIFF
--- a/Tests/Transport/PostalApiTransportTest.php
+++ b/Tests/Transport/PostalApiTransportTest.php
@@ -64,8 +64,11 @@ class PostalApiTransportTest extends TestCase
             $this->assertSame(base64_encode('some attachment'), $body['attachments'][0]['data']);
             $this->assertSame('foo@bar.fr', $body['reply_to']);
 
-            return new JsonMockResponse(['message_id' => 'foobar'], [
+            return new JsonMockResponse([
                 'http_code' => 200,
+                'data' => [
+                    'message_id' => 'foobar'
+                ],
             ]);
         });
         $transport = new PostalApiTransport('TOKEN', 'postal.localhost', $client);
@@ -88,8 +91,11 @@ class PostalApiTransportTest extends TestCase
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
-            return new JsonMockResponse(['message' => 'i\'m a teapot'], [
+            return new JsonMockResponse([
                 'http_code' => 418,
+                'data' => [
+                    'message' => 'i\'m a teapot'
+                ],
             ]);
         });
         $transport = new PostalApiTransport('TOKEN', 'postal.localhost', $client);

--- a/Tests/Transport/PostalTransportFactoryTest.php
+++ b/Tests/Transport/PostalTransportFactoryTest.php
@@ -47,20 +47,20 @@ class PostalTransportFactoryTest extends AbstractTransportFactoryTestCase
         $logger = new NullLogger();
 
         yield [
-            new Dsn('postal+api', 'postal.localhost', null, self::PASSWORD),
-            new PostalApiTransport(self::PASSWORD, 'postal.localhost', new MockHttpClient(), null, $logger),
+            new Dsn('postal+api', 'postal.localhost', null, self::USER),
+            new PostalApiTransport(self::USER, 'postal.localhost', new MockHttpClient(), null, $logger),
         ];
 
         yield [
-            new Dsn('postal', 'postal.localhost', null, self::PASSWORD),
-            new PostalApiTransport(self::PASSWORD, 'postal.localhost', new MockHttpClient(), null, $logger),
+            new Dsn('postal', 'postal.localhost', null, self::USER),
+            new PostalApiTransport(self::USER, 'postal.localhost', new MockHttpClient(), null, $logger),
         ];
     }
 
     public static function unsupportedSchemeProvider(): iterable
     {
         yield [
-            new Dsn('postal+foo', 'postal.localhost', null, self::PASSWORD),
+            new Dsn('postal+foo', 'postal.localhost', null, self::USER),
             'The "postal+foo" scheme is not supported; supported schemes for mailer "postal" are: "postal", "postal+api".',
         ];
     }

--- a/Transport/PostalApiTransport.php
+++ b/Transport/PostalApiTransport.php
@@ -64,7 +64,13 @@ final class PostalApiTransport extends AbstractApiTransport
             throw new HttpTransportException('Unable to send an email: '.$result['message'].\sprintf(' (code %d).', $statusCode), $response);
         }
 
-        $sentMessage->setMessageId($result['message_id']);
+        if(isset($result['message_id'])) {
+            $sentMessage->setMessageId($result['message_id']);
+        }
+
+        if(isset($result['data']['message_id'])) {
+            $sentMessage->setMessageId($result['data']['message_id']);
+        }
 
         return $response;
     }

--- a/Transport/PostalTransportFactory.php
+++ b/Transport/PostalTransportFactory.php
@@ -28,7 +28,7 @@ final class PostalTransportFactory extends AbstractTransportFactory
 
         $host = $dsn->getHost();
         $port = $dsn->getPort();
-        $apiToken = $this->getPassword($dsn);
+        $apiToken = $this->getUser($dsn);
 
         return (new PostalApiTransport($apiToken, $host, $this->client, $this->dispatcher, $this->logger))->setPort($port);
     }


### PR DESCRIPTION
Symfony version(s) affected

7.2 and up

Description

I am not familiar with postal2 but in postal3 the dsn has no password, also in postal 3 the message_id is inside the data key.

How to reproduce

just installing and using with a postal3 server

Possible Solution

in PostalTransportFactory.php calling $apiToken = $this->getPassword($dsn); results in a password not set error. but postal3 has only an api key. changing to $apiToken = $this->getUser($dsn); solves the probelm.

in PostalApiTransport.php the line $sentMessage->setMessageId($result['message_id']) throws an error. changing to $sentMessage->setMessageId($result['data']['message_id'])

Additional Context
[https://github.com/symfony/symfony/issues/60727#issue-3124309503](url)